### PR TITLE
Доработки по ответам API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 | Давление шин (ПЛ, ПП, ЗЛ, ЗП) | бар | Давление в каждой шине |
 | Скорость | км/ч | Текущая скорость автомобиля |
 | Расчётное время окончания зарядки | timestamp | Прогнозируемое время завершения зарядки (линейная экстраполяция) |
+| Температура в салоне | °C | Температура воздуха внутри салона автомобиля |
+| Время с последнего пинга | с | Время с момента последнего соединения автомобиля с сервером |
 
 #### Расчётное время окончания зарядки — алгоритм
 
@@ -251,6 +253,8 @@ Custom integration for [Home Assistant](https://www.home-assistant.io/) that con
 | Tire pressure (FL, FR, RL, RR) | bar | Individual tire pressures |
 | Speed | km/h | Current vehicle speed |
 | Estimated charging end time | timestamp | Projected completion time (linear extrapolation from observed charge rate) |
+| Interior temperature | °C | Air temperature inside the vehicle cabin |
+| Time since last ping | s | Seconds since the car last connected to the server |
 
 #### Estimated charging end time — algorithm
 

--- a/custom_components/voyah/api.py
+++ b/custom_components/voyah/api.py
@@ -152,6 +152,7 @@ class VoyahApiClient:
             "sensors_data": sensors_data,
             "position_data": position_data,
             "time": timestamp,
+            "last_ping": raw.get("lastPing"),
         }
 
     # ── Auth helpers (used by config_flow, not during polling) ──

--- a/custom_components/voyah/config_flow.py
+++ b/custom_components/voyah/config_flow.py
@@ -250,7 +250,8 @@ class VoyahConfigFlow(ConfigFlow, domain=DOMAIN):
 def _car_label(car: dict[str, Any]) -> str:
     """Human-readable label for a car."""
     parts: list[str] = []
-    model = car.get("model") or car.get("modelName")
+    car_model = car.get("carModel") or {}
+    model = car_model.get("displayName") or car_model.get("name") or car.get("model") or car.get("modelName")
     name = car.get("name")
     plate = car.get("plateNumber") or car.get("grz")
     vin = car.get("vin")

--- a/custom_components/voyah/const.py
+++ b/custom_components/voyah/const.py
@@ -77,6 +77,13 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
+        key="inBoardTemp",
+        translation_key="inboard_temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
         key="batteryTemp",
         translation_key="battery_temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,

--- a/custom_components/voyah/sensor.py
+++ b/custom_components/voyah/sensor.py
@@ -6,8 +6,9 @@ from collections import deque
 from datetime import datetime, timedelta, timezone
 import logging
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorEntityDescription, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -46,6 +47,9 @@ async def async_setup_entry(
 
     if "batteryPercentage" in sensors_data and "chargingStatus" in sensors_data:
         entities.append(VoyahChargingEndTimeSensor(coordinator, entry))
+
+    if "last_ping" in coordinator.data:
+        entities.append(VoyahLastPingSensor(coordinator, entry))
 
     _LOGGER.debug("Creating %d sensor entities", len(entities))
     async_add_entities(entities)
@@ -214,3 +218,33 @@ class VoyahChargingEndTimeSensor(CoordinatorEntity[VoyahDataUpdateCoordinator], 
         if not self._was_charging:
             return None
         return self._cached_end_time
+
+
+class VoyahLastPingSensor(CoordinatorEntity[VoyahDataUpdateCoordinator], SensorEntity):
+    """Sensor reporting seconds since the car last connected to the server."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_translation_key = "last_ping"
+    _attr_icon = "mdi:timer-outline"
+
+    def __init__(
+        self,
+        coordinator: VoyahDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        car_id = entry.data.get(CONF_CAR_ID, entry.entry_id)
+        self._attr_unique_id = f"{car_id}_last_ping"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, car_id)},
+            name=entry.data.get(CONF_CAR_NAME, "Voyah"),
+            manufacturer="Voyah",
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return seconds since the last ping from the car."""
+        return self.coordinator.data.get("last_ping")

--- a/custom_components/voyah/translations/en.json
+++ b/custom_components/voyah/translations/en.json
@@ -74,7 +74,9 @@
             "tire_pressure_rear_left": { "name": "Tire pressure rear left" },
             "tire_pressure_rear_right": { "name": "Tire pressure rear right" },
             "speed": { "name": "Speed" },
-            "charging_end_time": { "name": "Estimated charging end time" }
+            "charging_end_time": { "name": "Estimated charging end time" },
+            "inboard_temperature": { "name": "Interior temperature" },
+            "last_ping": { "name": "Last ping" }
         },
         "device_tracker": {
             "location": { "name": "Location" }

--- a/custom_components/voyah/translations/ru.json
+++ b/custom_components/voyah/translations/ru.json
@@ -1,0 +1,110 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Voyah — Номер телефона",
+                "description": "Введите номер телефона для получения SMS-кода.",
+                "data": {
+                    "phone": "Номер телефона"
+                },
+                "data_description": {
+                    "phone": "Формат: 79001234567 (11 цифр)"
+                }
+            },
+            "code": {
+                "title": "Voyah — SMS-код",
+                "description": "На номер {phone} отправлен SMS-код.",
+                "data": {
+                    "code": "SMS-код"
+                }
+            },
+            "organization": {
+                "title": "Voyah — Организация",
+                "description": "Выберите организацию.",
+                "data": {
+                    "organization": "Организация"
+                }
+            },
+            "car": {
+                "title": "Voyah — Выбор автомобиля",
+                "description": "Выберите автомобиль для мониторинга.",
+                "data": {
+                    "car": "Автомобиль"
+                }
+            },
+            "reauth_confirm": {
+                "title": "Voyah — Повторная аутентификация",
+                "description": "Сессия истекла. Введите номер телефона для получения нового SMS-кода.",
+                "data": {
+                    "phone": "Номер телефона"
+                },
+                "data_description": {
+                    "phone": "Формат: 79001234567 (11 цифр)"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "Не удалось подключиться к API Voyah",
+            "invalid_code": "Неверный SMS-код",
+            "invalid_auth": "Ошибка аутентификации",
+            "unknown": "Неожиданная ошибка"
+        },
+        "abort": {
+            "already_configured": "Этот автомобиль уже настроен",
+            "no_cars": "Для этого аккаунта не найдено автомобилей",
+            "reauth_successful": "Повторная аутентификация выполнена успешно",
+            "unique_id_mismatch": "Выбранный автомобиль не совпадает с настроенным. Повторная аутентификация возможна только для того же автомобиля."
+        }
+    },
+    "entity": {
+        "sensor": {
+            "battery_percentage": { "name": "Батарея" },
+            "remains_mileage": { "name": "Запас хода (электро)" },
+            "fuel_percentage": { "name": "Уровень топлива" },
+            "remains_mileage_fuel": { "name": "Запас хода (топливо)" },
+            "battery_voltage_12v": { "name": "Напряжение 12V батареи" },
+            "odometer": { "name": "Одометр" },
+            "outside_temperature": { "name": "Температура снаружи" },
+            "inboard_temperature": { "name": "Температура в салоне" },
+            "battery_temperature": { "name": "Температура батареи" },
+            "coolant_temperature": { "name": "Температура охлаждающей жидкости" },
+            "climate_target_temperature": { "name": "Целевая температура климата" },
+            "climate_fan_speed": { "name": "Скорость вентилятора климата" },
+            "tire_pressure_front_left": { "name": "Давление шины спереди слева" },
+            "tire_pressure_front_right": { "name": "Давление шины спереди справа" },
+            "tire_pressure_rear_left": { "name": "Давление шины сзади слева" },
+            "tire_pressure_rear_right": { "name": "Давление шины сзади справа" },
+            "speed": { "name": "Скорость" },
+            "charging_end_time": { "name": "Расчётное время окончания зарядки" },
+            "last_ping": { "name": "Последний пинг" }
+        },
+        "device_tracker": {
+            "location": { "name": "Местоположение" }
+        },
+        "button": {
+            "start_heating": { "name": "Запуск обогрева" }
+        },
+        "binary_sensor": {
+            "ignition": { "name": "Зажигание" },
+            "charging": { "name": "Зарядка" },
+            "central_locking": { "name": "Центральный замок" },
+            "door_front_left": { "name": "Дверь спереди слева" },
+            "door_front_right": { "name": "Дверь спереди справа" },
+            "door_rear_left": { "name": "Дверь сзади слева" },
+            "trunk": { "name": "Багажник" },
+            "hatch": { "name": "Хэтчбек" },
+            "climate": { "name": "Климат" },
+            "security": { "name": "Охрана" },
+            "headlights": { "name": "Фары" },
+            "ready": { "name": "Готовность" },
+            "airing": { "name": "Проветривание" },
+            "climate_front_window": { "name": "Обогрев лобового стекла" },
+            "mirrors_heating": { "name": "Обогрев зеркал" },
+            "wheel_heating": { "name": "Обогрев руля" },
+            "seat_heating_driver": { "name": "Обогрев сиденья водителя" },
+            "seat_heating_front_passenger": { "name": "Обогрев сиденья переднего пассажира" },
+            "seat_heating_rear_left": { "name": "Обогрев сиденья сзади слева" },
+            "seat_heating_rear_right": { "name": "Обогрев сиденья сзади справа" }
+        }
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ MOCK_CAR_DATA = {
         "12VBatteryVoltage": 12.5,
         "odometer": 15000,
         "outsideTemp": 20,
+        "inBoardTemp": 22,
         "batteryTemp": 25,
         "coolantTemp": 30,
         "climateTargetTemp": 22,
@@ -74,12 +75,13 @@ MOCK_CAR_DATA = {
         "lat": 55.7558,
         "lon": 37.6176,
         "course": 90,
-        "alt": 150,
-        "sat": 8,
+        "height": 150,
+        "sats": 8,
         "hdop": 1.2,
         "speed": 0,
     },
     "time": 1700000000,
+    "last_ping": 6.614,
 }
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,6 +8,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.voyah.api import VoyahApiAuthError, VoyahApiConnectionError
+from custom_components.voyah.config_flow import _car_label
 from custom_components.voyah.const import DOMAIN
 
 from .conftest import MOCK_ACCESS_TOKEN, MOCK_CAR_ID, MOCK_CONFIG_DATA, MOCK_PHONE, MOCK_REFRESH_TOKEN
@@ -205,3 +206,43 @@ async def test_duplicate_entry_aborts(hass: HomeAssistant) -> None:
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+def test_car_label_uses_car_model_display_name() -> None:
+    """_car_label reads model name from carModel.displayName."""
+    car = {
+        "_id": "aabbccddeeff001122334455",
+        "vin": "TEST0000000000001",
+        "carModel": {
+            "name": "Dream",
+            "displayName": "МЕЧТА / DREAM",
+        },
+    }
+    label = _car_label(car)
+    assert "МЕЧТА / DREAM" in label
+    assert "TEST0000000000001" in label
+
+
+def test_car_label_falls_back_to_car_model_name() -> None:
+    """_car_label falls back to carModel.name when displayName is absent."""
+    car = {
+        "_id": "abc123",
+        "vin": "VIN000",
+        "carModel": {"name": "Free"},
+    }
+    label = _car_label(car)
+    assert "Free" in label
+
+
+def test_car_label_falls_back_to_top_level_model() -> None:
+    """_car_label falls back to top-level model/modelName keys for old API format."""
+    car = {"_id": "abc123", "vin": "VIN000", "model": "Free"}
+    label = _car_label(car)
+    assert "Free" in label
+
+
+def test_car_label_only_vin_when_no_model() -> None:
+    """_car_label shows only VIN when no model info is present."""
+    car = {"_id": "abc123", "vin": "TEST0000000000002"}
+    label = _car_label(car)
+    assert label == "(TEST0000000000002)"

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -53,8 +53,8 @@ async def test_tracker_extra_state_attributes(hass: HomeAssistant) -> None:
 
     assert attrs["course"] == 90
     assert attrs["hdop"] == 1.2
-    assert "altitude" in attrs
-    assert "satellites" in attrs
+    assert attrs["altitude"] == 150
+    assert attrs["satellites"] == 8
 
 
 async def test_tracker_returns_none_when_position_missing(hass: HomeAssistant) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,7 +9,12 @@ from homeassistant.core import HomeAssistant
 import time_machine
 
 from custom_components.voyah.const import SENSOR_DESCRIPTIONS
-from custom_components.voyah.sensor import RATE_WINDOW_POINTS, VoyahChargingEndTimeSensor, VoyahSensorEntity
+from custom_components.voyah.sensor import (
+    RATE_WINDOW_POINTS,
+    VoyahChargingEndTimeSensor,
+    VoyahLastPingSensor,
+    VoyahSensorEntity,
+)
 
 from .conftest import MOCK_CAR_DATA, make_config_entry, make_coordinator
 
@@ -32,6 +37,32 @@ async def test_sensor_returns_none_for_missing_key(hass: HomeAssistant) -> None:
     entry = make_config_entry(hass)
     desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "batteryPercentage")
     sensor = VoyahSensorEntity(coordinator, desc, entry)
+    assert sensor.native_value is None
+
+
+async def test_inboard_temp_sensor_returns_value(hass: HomeAssistant) -> None:
+    """inBoardTemp sensor reads value from coordinator sensors_data."""
+    coordinator = make_coordinator(hass, MOCK_CAR_DATA)
+    entry = make_config_entry(hass)
+    desc = next(d for d in SENSOR_DESCRIPTIONS if d.key == "inBoardTemp")
+    sensor = VoyahSensorEntity(coordinator, desc, entry)
+    assert sensor.native_value == 22
+
+
+async def test_last_ping_sensor_returns_value(hass: HomeAssistant) -> None:
+    """VoyahLastPingSensor reads last_ping from coordinator data."""
+    coordinator = make_coordinator(hass, MOCK_CAR_DATA)
+    entry = make_config_entry(hass)
+    sensor = VoyahLastPingSensor(coordinator, entry)
+    assert sensor.native_value == 6.614
+
+
+async def test_last_ping_sensor_returns_none_when_missing(hass: HomeAssistant) -> None:
+    """VoyahLastPingSensor returns None when last_ping is absent from data."""
+    data = {k: v for k, v in MOCK_CAR_DATA.items() if k != "last_ping"}
+    coordinator = make_coordinator(hass, data)
+    entry = make_config_entry(hass)
+    sensor = VoyahLastPingSensor(coordinator, entry)
     assert sensor.native_value is None
 
 


### PR DESCRIPTION
  1. Исправлены ключи position_data в тестовых данных
Мок использовал alt/sat, но реальный API возвращает height/sats. Код device_tracker.py обращался к правильным ключам, поэтому тесты молча проверяли None вместо реальных значений. Заодно усилены проверки: теперь тест проверяет конкретные значения altitude и satellites, а не просто наличие ключей.

2. _car_label() теперь читает имя модели из carModel
Реальный API возвращает название модели в car.carModel.displayName / car.carModel.name, а не на верхнем уровне объекта. Из-за этого у меня после настройки интеграции устройство называлось только VIN-номером в скобках, без названия модели.

3. Новый сенсор: температура в салоне (inBoardTemp)
Поле присутствует в каждом ответе /sensors, но не было представлено в интеграции. Добавлены описание сенсора, переводы (ru/en), тест, строка в README.

4. Новый сенсор: время с последнего пинга (lastPing)
Показывает, сколько секунд назад автомобиль последний раз выходил на связь с сервером — полезно для диагностики. Поле находится на верхнем уровне ответа API (не в sensorsData), поэтому добавлено отдельное извлечение в _parse() и отдельный класс сенсора. Добавлены переводы (ru/en), тест, строка в README.