### PR TITLE
Добавил получение SOH батареи

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 | Давление шин (ПЛ, ПП, ЗЛ, ЗП) | бар | Давление в каждой шине |
 | Скорость | км/ч | Текущая скорость автомобиля |
 | Расчётное время окончания зарядки | timestamp | Прогнозируемое время завершения зарядки (линейная экстраполяция) |
+| Здоровье батареи (SOH) | % | Состояние здоровья высоковольтной батареи (>100% — новая батарея) |
 
 #### Расчётное время окончания зарядки — алгоритм
 
@@ -251,6 +252,7 @@ Custom integration for [Home Assistant](https://www.home-assistant.io/) that con
 | Tire pressure (FL, FR, RL, RR) | bar | Individual tire pressures |
 | Speed | km/h | Current vehicle speed |
 | Estimated charging end time | timestamp | Projected completion time (linear extrapolation from observed charge rate) |
+| Battery SOH | % | State of health of the high-voltage battery (>100% means new battery) |
 
 #### Estimated charging end time — algorithm
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@
 | Температура в салоне | °C | Температура воздуха внутри салона автомобиля |
 | Время с последнего пинга | с | Время с момента последнего соединения автомобиля с сервером |
 
+#### Здоровье батареи (SOH) — примечания
+
+Значение обновляется раз в 12 часов (данные меняются медленно). Значение >100% норма для новой батареи — API возвращает калиброванное значение относительно номинальной ёмкости.
+
 #### Расчётное время окончания зарядки — алгоритм
 
 Сенсор оценивает, когда батарея достигнет 100%, используя скользящее окно последних 3% для расчёта текущей скорости зарядки.
@@ -257,6 +261,10 @@ Custom integration for [Home Assistant](https://www.home-assistant.io/) that con
 | Battery SOH | % | State of health of the high-voltage battery (>100% means new battery) |
 | Interior temperature | °C | Air temperature inside the vehicle cabin |
 | Time since last ping | s | Seconds since the car last connected to the server |
+
+#### Battery SOH — notes
+
+Updated every 12 hours (the value changes slowly). A value >100% is normal for a new battery — the API returns a calibrated value relative to the nominal capacity.
 
 #### Estimated charging end time — algorithm
 

--- a/custom_components/voyah/__init__.py
+++ b/custom_components/voyah/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import VoyahApiClient
 from .const import CONF_ACCESS_TOKEN, CONF_CAR_ID, CONF_REFRESH_TOKEN, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN
-from .coordinator import VoyahDataUpdateCoordinator
+from .coordinator import VoyahCarInfoCoordinator, VoyahDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -33,7 +33,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = VoyahDataUpdateCoordinator(hass, client, entry, scan_interval)
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    car_info_coordinator = VoyahCarInfoCoordinator(hass, client, entry)
+    await car_info_coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "coordinator": coordinator,
+        "car_info_coordinator": car_info_coordinator,
+    }
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/custom_components/voyah/api.py
+++ b/custom_components/voyah/api.py
@@ -121,6 +121,13 @@ class VoyahApiClient:
             json_data={},
         )
 
+    async def async_get_car_info(self) -> dict[str, Any]:
+        """Fetch static car info including SOH from car/v2 endpoint."""
+        return await self._request(
+            "GET",
+            f"/car-service/car/v2/{self._car_id}",
+        )
+
     async def async_get_car_data(self) -> dict[str, Any]:
         """Fetch full telemetry from the tbox endpoint."""
         raw = await self._request(

--- a/custom_components/voyah/binary_sensor.py
+++ b/custom_components/voyah/binary_sensor.py
@@ -19,7 +19,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Voyah binary sensor entities."""
-    coordinator: VoyahDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: VoyahDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     async_add_entities(
         VoyahBinarySensorEntity(coordinator, description, entry)

--- a/custom_components/voyah/button.py
+++ b/custom_components/voyah/button.py
@@ -23,7 +23,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Voyah button entities."""
-    coordinator: VoyahDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: VoyahDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     async_add_entities([VoyahStartHeatingButton(coordinator, entry)])
 
 

--- a/custom_components/voyah/coordinator.py
+++ b/custom_components/voyah/coordinator.py
@@ -66,3 +66,34 @@ class VoyahDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             new_data[CONF_REFRESH_TOKEN] = new_refresh
             self.hass.config_entries.async_update_entry(self._entry, data=new_data)
             _LOGGER.debug("Persisted refreshed tokens to config entry")
+
+
+CAR_INFO_UPDATE_INTERVAL = timedelta(hours=12)
+
+
+class VoyahCarInfoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator for slow-changing car info (SOH, etc.) fetched every 12 hours."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: VoyahApiClient,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_car_info",
+            update_interval=CAR_INFO_UPDATE_INTERVAL,
+        )
+        self.client = client
+        self._entry = entry
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch car info from the API."""
+        try:
+            return await self.client.async_get_car_info()
+        except VoyahApiAuthError as err:
+            raise ConfigEntryAuthFailed(err) from err
+        except VoyahApiError as err:
+            raise UpdateFailed(f"Error fetching Voyah car info: {err}") from err

--- a/custom_components/voyah/device_tracker.py
+++ b/custom_components/voyah/device_tracker.py
@@ -22,7 +22,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Voyah device tracker."""
-    coordinator: VoyahDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: VoyahDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     position_data = coordinator.data.get("position_data", {})
     if position_data.get("lat") is not None and position_data.get("lon") is not None:

--- a/custom_components/voyah/sensor.py
+++ b/custom_components/voyah/sensor.py
@@ -6,7 +6,8 @@ from collections import deque
 from datetime import datetime, timedelta, timezone
 import logging
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorEntityDescription, SensorStateClass
+from homeassistant.const import PERCENTAGE
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -14,7 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_CAR_ID, CONF_CAR_NAME, DOMAIN, SENSOR_DESCRIPTIONS
-from .coordinator import VoyahDataUpdateCoordinator
+from .coordinator import VoyahCarInfoCoordinator, VoyahDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Voyah sensor entities."""
-    coordinator: VoyahDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: VoyahDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     _LOGGER.debug(
         "Setting up sensors. coordinator.data type=%s, value=%s",
@@ -46,6 +47,12 @@ async def async_setup_entry(
 
     if "batteryPercentage" in sensors_data and "chargingStatus" in sensors_data:
         entities.append(VoyahChargingEndTimeSensor(coordinator, entry))
+
+    car_info_coordinator: VoyahCarInfoCoordinator = hass.data[DOMAIN][entry.entry_id]["car_info_coordinator"]
+    car_info = car_info_coordinator.data or {}
+    live_sensors = car_info.get("liveSensors") or {}
+    if "soh" in live_sensors:
+        entities.append(VoyahSohSensor(car_info_coordinator, entry))
 
     _LOGGER.debug("Creating %d sensor entities", len(entities))
     async_add_entities(entities)
@@ -214,3 +221,28 @@ class VoyahChargingEndTimeSensor(CoordinatorEntity[VoyahDataUpdateCoordinator], 
         if not self._was_charging:
             return None
         return self._cached_end_time
+
+
+class VoyahSohSensor(CoordinatorEntity[VoyahCarInfoCoordinator], SensorEntity):
+    """State of Health sensor for the high-voltage battery."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "battery_soh"
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:battery-heart"
+
+    def __init__(self, coordinator: VoyahCarInfoCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        car_id = entry.data.get(CONF_CAR_ID, entry.entry_id)
+        self._attr_unique_id = f"{car_id}_battery_soh"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, car_id)},
+            name=entry.data.get(CONF_CAR_NAME, "Voyah"),
+            manufacturer="Voyah",
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        live = (self.coordinator.data or {}).get("liveSensors") or {}
+        return live.get("soh")

--- a/custom_components/voyah/translations/en.json
+++ b/custom_components/voyah/translations/en.json
@@ -74,7 +74,8 @@
             "tire_pressure_rear_left": { "name": "Tire pressure rear left" },
             "tire_pressure_rear_right": { "name": "Tire pressure rear right" },
             "speed": { "name": "Speed" },
-            "charging_end_time": { "name": "Estimated charging end time" }
+            "charging_end_time": { "name": "Estimated charging end time" },
+            "battery_soh": { "name": "Battery SOH" }
         },
         "device_tracker": {
             "location": { "name": "Location" }

--- a/custom_components/voyah/translations/ru.json
+++ b/custom_components/voyah/translations/ru.json
@@ -1,0 +1,109 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Voyah — Номер телефона",
+                "description": "Введите номер телефона для получения SMS-кода.",
+                "data": {
+                    "phone": "Номер телефона"
+                },
+                "data_description": {
+                    "phone": "Формат: 79001234567 (11 цифр)"
+                }
+            },
+            "code": {
+                "title": "Voyah — SMS-код",
+                "description": "На номер {phone} отправлен SMS-код.",
+                "data": {
+                    "code": "SMS-код"
+                }
+            },
+            "organization": {
+                "title": "Voyah — Организация",
+                "description": "Выберите организацию.",
+                "data": {
+                    "organization": "Организация"
+                }
+            },
+            "car": {
+                "title": "Voyah — Выбор автомобиля",
+                "description": "Выберите автомобиль для мониторинга.",
+                "data": {
+                    "car": "Автомобиль"
+                }
+            },
+            "reauth_confirm": {
+                "title": "Voyah — Повторная аутентификация",
+                "description": "Сессия истекла. Введите номер телефона для получения нового SMS-кода.",
+                "data": {
+                    "phone": "Номер телефона"
+                },
+                "data_description": {
+                    "phone": "Формат: 79001234567 (11 цифр)"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "Не удалось подключиться к API Voyah",
+            "invalid_code": "Неверный SMS-код",
+            "invalid_auth": "Ошибка аутентификации",
+            "unknown": "Непредвиденная ошибка"
+        },
+        "abort": {
+            "already_configured": "Этот автомобиль уже настроен",
+            "no_cars": "Автомобили для этого аккаунта не найдены",
+            "reauth_successful": "Повторная аутентификация выполнена успешно",
+            "unique_id_mismatch": "Выбранный автомобиль не совпадает с настроенным. Повторная аутентификация возможна только для того же автомобиля."
+        }
+    },
+    "entity": {
+        "sensor": {
+            "battery_percentage": { "name": "Батарея" },
+            "remains_mileage": { "name": "Запас хода (электро)" },
+            "fuel_percentage": { "name": "Уровень топлива" },
+            "remains_mileage_fuel": { "name": "Запас хода (топливо)" },
+            "battery_voltage_12v": { "name": "Напряжение 12V батареи" },
+            "odometer": { "name": "Одометр" },
+            "outside_temperature": { "name": "Температура снаружи" },
+            "battery_temperature": { "name": "Температура батареи" },
+            "coolant_temperature": { "name": "Температура охлаждающей жидкости" },
+            "climate_target_temperature": { "name": "Целевая температура климата" },
+            "climate_fan_speed": { "name": "Скорость вентилятора климата" },
+            "tire_pressure_front_left": { "name": "Давление шины передняя левая" },
+            "tire_pressure_front_right": { "name": "Давление шины передняя правая" },
+            "tire_pressure_rear_left": { "name": "Давление шины задняя левая" },
+            "tire_pressure_rear_right": { "name": "Давление шины задняя правая" },
+            "speed": { "name": "Скорость" },
+            "charging_end_time": { "name": "Расчётное время окончания зарядки" },
+            "battery_soh": { "name": "Здоровье батареи (SOH)" }
+        },
+        "device_tracker": {
+            "location": { "name": "Местоположение" }
+        },
+        "button": {
+            "start_heating": { "name": "Запуск обогрева" }
+        },
+        "binary_sensor": {
+            "ignition": { "name": "Зажигание" },
+            "charging": { "name": "Зарядка" },
+            "central_locking": { "name": "Центральный замок" },
+            "door_front_left": { "name": "Дверь передняя левая" },
+            "door_front_right": { "name": "Дверь передняя правая" },
+            "door_rear_left": { "name": "Дверь задняя левая" },
+            "trunk": { "name": "Багажник" },
+            "hatch": { "name": "Хэтчбек" },
+            "climate": { "name": "Климат" },
+            "security": { "name": "Охрана" },
+            "headlights": { "name": "Фары" },
+            "ready": { "name": "Готовность" },
+            "airing": { "name": "Проветривание" },
+            "climate_front_window": { "name": "Обогрев лобового стекла" },
+            "mirrors_heating": { "name": "Обогрев зеркал" },
+            "wheel_heating": { "name": "Обогрев руля" },
+            "seat_heating_driver": { "name": "Обогрев сиденья водителя" },
+            "seat_heating_front_passenger": { "name": "Обогрев сиденья переднего пассажира" },
+            "seat_heating_rear_left": { "name": "Обогрев сиденья заднего левого" },
+            "seat_heating_rear_right": { "name": "Обогрев сиденья заднего правого" }
+        }
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from custom_components.voyah.const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
-from custom_components.voyah.coordinator import VoyahDataUpdateCoordinator
+from custom_components.voyah.coordinator import VoyahCarInfoCoordinator, VoyahDataUpdateCoordinator
 
 MOCK_CAR_ID = "car-abc123"
 MOCK_PHONE = "79001234567"
@@ -29,6 +29,11 @@ MOCK_CONFIG_DATA = {
     CONF_CAR_ID: MOCK_CAR_ID,
     CONF_CAR_NAME: "Voyah Free",
     CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+}
+
+MOCK_CAR_INFO_DATA = {
+    "liveSensors": {"odometer": 251, "soh": 98},
+    "updateAvailable": False,
 }
 
 MOCK_CAR_DATA = {
@@ -88,6 +93,15 @@ def make_coordinator(hass: HomeAssistant, data: dict):
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA)
     entry.add_to_hass(hass)
     coordinator = VoyahDataUpdateCoordinator(hass, MagicMock(), entry, update_interval=60)
+    coordinator.data = data
+    return coordinator
+
+
+def make_car_info_coordinator(hass: HomeAssistant, data: dict):
+    """Create a VoyahCarInfoCoordinator with pre-set data."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA)
+    entry.add_to_hass(hass)
+    coordinator = VoyahCarInfoCoordinator(hass, MagicMock(), entry)
     coordinator.data = data
     return coordinator
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -122,3 +122,14 @@ async def test_sign_in_returns_tokens_on_success() -> None:
 
     result = await VoyahApiClient.async_sign_in(session, "79001234567", "123456")
     assert result["accessToken"] == "acc"
+
+
+async def test_get_car_info_success() -> None:
+    """async_get_car_info returns dict from API on 200."""
+    car_info = {"liveSensors": {"soh": 98}}
+    session = MagicMock()
+    session.request = MagicMock(return_value=_mock_response(200, car_info))
+
+    client = _make_client(session)
+    result = await client.async_get_car_info()
+    assert result == {"liveSensors": {"soh": 98}}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,9 +10,9 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.voyah.api import VoyahApiAuthError, VoyahApiError
 from custom_components.voyah.const import DOMAIN
-from custom_components.voyah.coordinator import VoyahDataUpdateCoordinator
+from custom_components.voyah.coordinator import VoyahCarInfoCoordinator, VoyahDataUpdateCoordinator
 
-from .conftest import MOCK_CAR_DATA, MOCK_CONFIG_DATA
+from .conftest import MOCK_CAR_DATA, MOCK_CAR_INFO_DATA, MOCK_CONFIG_DATA
 
 
 def _make_coordinator_with_entry(
@@ -59,6 +59,47 @@ async def test_coordinator_raises_auth_failed_on_auth_error(hass: HomeAssistant)
     client.async_get_car_data = AsyncMock(side_effect=VoyahApiAuthError("expired"))
 
     coordinator, _ = _make_coordinator_with_entry(hass, client)
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
+def _make_car_info_coordinator_with_entry(
+    hass: HomeAssistant, client: MagicMock
+) -> tuple[VoyahCarInfoCoordinator, MockConfigEntry]:
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA)
+    entry.add_to_hass(hass)
+    coordinator = VoyahCarInfoCoordinator(hass, client, entry)
+    coordinator.config_entry = entry
+    return coordinator, entry
+
+
+async def test_car_info_coordinator_fetches_data(hass: HomeAssistant) -> None:
+    """VoyahCarInfoCoordinator returns car info data from API on success."""
+    client = MagicMock()
+    client.async_get_car_info = AsyncMock(return_value=MOCK_CAR_INFO_DATA)
+
+    coordinator, _ = _make_car_info_coordinator_with_entry(hass, client)
+    data = await coordinator._async_update_data()
+
+    assert data["liveSensors"]["soh"] == 98
+
+
+async def test_car_info_coordinator_raises_update_failed_on_api_error(hass: HomeAssistant) -> None:
+    """VoyahApiError raises UpdateFailed in VoyahCarInfoCoordinator."""
+    client = MagicMock()
+    client.async_get_car_info = AsyncMock(side_effect=VoyahApiError("api error"))
+
+    coordinator, _ = _make_car_info_coordinator_with_entry(hass, client)
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+
+async def test_car_info_coordinator_raises_auth_failed_on_auth_error(hass: HomeAssistant) -> None:
+    """VoyahApiAuthError raises ConfigEntryAuthFailed in VoyahCarInfoCoordinator."""
+    client = MagicMock()
+    client.async_get_car_info = AsyncMock(side_effect=VoyahApiAuthError("auth error"))
+
+    coordinator, _ = _make_car_info_coordinator_with_entry(hass, client)
     with pytest.raises(ConfigEntryAuthFailed):
         await coordinator._async_update_data()
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,9 +9,11 @@ from homeassistant.core import HomeAssistant
 import time_machine
 
 from custom_components.voyah.const import SENSOR_DESCRIPTIONS
-from custom_components.voyah.sensor import RATE_WINDOW_POINTS, VoyahChargingEndTimeSensor, VoyahSensorEntity
+from custom_components.voyah.coordinator import VoyahCarInfoCoordinator
+from custom_components.voyah.sensor import RATE_WINDOW_POINTS, VoyahChargingEndTimeSensor, VoyahSensorEntity, VoyahSohSensor
 
-from .conftest import MOCK_CAR_DATA, make_config_entry, make_coordinator
+from .conftest import MOCK_CAR_DATA, MOCK_CAR_INFO_DATA, make_car_info_coordinator, make_config_entry, make_coordinator
+from .conftest import MOCK_CAR_ID
 
 # ── VoyahSensorEntity ────────────────────────────────────────────────────────
 
@@ -267,3 +269,30 @@ async def test_sliding_window_limited_to_max_points(hass: HomeAssistant) -> None
             sensor._handle_coordinator_update()
 
     assert len(sensor._pct_history) == RATE_WINDOW_POINTS
+
+
+# ── VoyahSohSensor ───────────────────────────────────────────────────────────
+
+
+async def test_soh_sensor_returns_value(hass: HomeAssistant) -> None:
+    """SOH sensor reads soh value from car info coordinator data."""
+    coordinator = make_car_info_coordinator(hass, MOCK_CAR_INFO_DATA)
+    entry = make_config_entry(hass)
+    sensor = VoyahSohSensor(coordinator, entry)
+    assert sensor.native_value == 98
+
+
+async def test_soh_sensor_returns_none_when_missing(hass: HomeAssistant) -> None:
+    """SOH sensor returns None when data is empty."""
+    coordinator = make_car_info_coordinator(hass, {})
+    entry = make_config_entry(hass)
+    sensor = VoyahSohSensor(coordinator, entry)
+    assert sensor.native_value is None
+
+
+async def test_soh_sensor_unique_id(hass: HomeAssistant) -> None:
+    """SOH sensor unique_id is formatted as {car_id}_battery_soh."""
+    coordinator = make_car_info_coordinator(hass, MOCK_CAR_INFO_DATA)
+    entry = make_config_entry(hass)
+    sensor = VoyahSohSensor(coordinator, entry)
+    assert sensor.unique_id == f"{MOCK_CAR_ID}_battery_soh"


### PR DESCRIPTION
  Добавляет сенсор **State of Health (SOH)** — показатель здоровья высоковольтной батареи в процентах. Значение >100% означает новую батарею.

  - **Новый эндпоинт** `GET /car-service/car/v2/{car_id}` — возвращает статичную информацию об автомобиле
  - **`VoyahCarInfoCoordinator`** — отдельный координатор с интервалом обновления 12 часов (данные меняются медленно)
  - **`VoyahSohSensor`** — новый сенсор, регистрируется только если `soh` присутствует в ответе API (паттерн проекта)
  - `VoyahCarInfoCoordinator` поднимается через `async_refresh()` (не `async_config_entry_first_refresh`), чтобы недоступность эндпоинта не блокировала запуск интеграции