### PR TITLE
fix(config_flow): заменить устаревший FlowResult на ConfigFlowResult

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,8 @@ tests/                 # юнит-тесты, общие фикстуры в con
 ## Релиз
 
 - Поднять `version` в `custom_components/voyah/manifest.json`.
-- Минимальная версия HA задана в `hacs.json` (`homeassistant: 2024.1.0`) — не использовать
-  API ядра новее без её поднятия.
+- Минимальная версия HA задана в `hacs.json` (`homeassistant: 2024.11.0`) — не использовать
+  API ядра новее без её поднятия. Планка 2024.11 продиктована хелперами reauth
+  (`_get_reauth_entry`, `_abort_if_unique_id_mismatch`, `async_update_reload_and_abort(data_updates=...)`)
+  и типом `ConfigFlowResult`.
 - HACS подтягивает версии из GitHub-релизов — после поднятия версии создать релиз.

--- a/custom_components/voyah/config_flow.py
+++ b/custom_components/voyah/config_flow.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry, ConfigFlow
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import voluptuous as vol
 
@@ -42,7 +41,7 @@ class VoyahConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reauth(
         self,
         entry_data: dict[str, Any],
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Start reauthentication flow when tokens expire."""
         self._reauth_entry = self._get_reauth_entry()
         self._phone = entry_data.get(CONF_PHONE, "")
@@ -51,7 +50,7 @@ class VoyahConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reauth_confirm(
         self,
         user_input: dict[str, Any] | None = None,
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Step: confirm phone and request new SMS."""
         errors: dict[str, str] = {}
 
@@ -83,7 +82,7 @@ class VoyahConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Step 1: enter phone number and request SMS."""
         errors: dict[str, str] = {}
 
@@ -103,7 +102,7 @@ class VoyahConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_code(
         self,
         user_input: dict[str, Any] | None = None,
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Step 2: enter SMS code."""
         errors: dict[str, str] = {}
 
@@ -151,7 +150,7 @@ class VoyahConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_organization(
         self,
         user_input: dict[str, Any] | None = None,
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Step 3 (optional): select organization."""
         errors: dict[str, str] = {}
 
@@ -179,7 +178,7 @@ class VoyahConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def _async_load_cars(self) -> FlowResult:
+    async def _async_load_cars(self) -> ConfigFlowResult:
         """Fetch car list and proceed to car selection."""
         session = async_get_clientsession(self.hass)
         self._cars = await VoyahApiClient.async_search_cars(session, self._access_token)
@@ -196,7 +195,7 @@ class VoyahConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_car(
         self,
         user_input: dict[str, Any] | None = None,
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Step 4: select a car."""
         if user_input is not None:
             car_id = user_input["car"]
@@ -213,7 +212,7 @@ class VoyahConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({vol.Required("car"): vol.In(car_options)}),
         )
 
-    async def _async_create_entry(self, car: dict[str, Any]) -> FlowResult:
+    async def _async_create_entry(self, car: dict[str, Any]) -> ConfigFlowResult:
         """Create or update the config entry for a selected car."""
         car_id = car.get("_id", car.get("id"))
         car_name = _car_label(car)

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Voyah",
   "render_readme": true,
-  "homeassistant": "2024.1.0"
+  "homeassistant": "2024.11.0"
 }


### PR DESCRIPTION
Closes #11

## Что сделано

- `custom_components/voyah/config_flow.py` — импорт `ConfigFlowResult` из `homeassistant.config_entries`, импорт `FlowResult` из `homeassistant.data_entry_flow` удалён, все 8 аннотаций возврата заменены.
- `hacs.json` — минимум HA поднят `2024.1.0` → `2024.11.0`.
- `AGENTS.md` — зафиксировано, чем продиктована планка 2024.11.

## Почему поднят минимум HA

`ConfigFlowResult` требует HA ≥ 2024.4, но заявленный минимум `2024.1.0` был неверен и до этого изменения: config flow уже использует `_get_reauth_entry()`, `_abort_if_unique_id_mismatch()` и `data_updates=` в `async_update_reload_and_abort()` — эти хелперы появились только в [2024.11](https://developers.home-assistant.io/blog/2024/10/21/reauth-reconfigure-helpers/). На 2024.1 интеграция упала бы при reauth ещё раньше.

`FlowResultType` в `tests/test_config_flow.py` не трогал — он живёт в `data_entry_flow` и не депрекейтнут.

## Проверки

```
65 passed
ruff check .        → All checks passed!
ruff format --check → 24 files already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
